### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -88,7 +88,7 @@ The selectors are essential in mcfunction. There are many reasons and justificat
 ### 2.1.1. Which target selector choosing ?
 
 
-`@e` is the generic selector, it selects all entities. To this selector you can add target selectors (I will not handle all of them; you can find them all [here on the wiki](https://minecraft.fandom.com/wiki/Target_selectors)). So to recap, `@e[type=minecraft:player]` will select only players.
+`@e` is the generic selector, it selects all entities. To this selector you can add target selectors (I will not handle all of them; you can find them all [here on the wiki](https://minecraft.wiki/w/Target_selectors)). So to recap, `@e[type=minecraft:player]` will select only players.
 
 We can find properties of `@e` in other selectors, but they still have their own properties:
 
@@ -162,7 +162,7 @@ With these details, we can now determine the best order:
 > `type` is always checked first regardless of order when an exact entity (not with entity tags). Additionally, this check uses an efficient class type check which is more performant than any other check. *(cf. **5.7.**)*
 
 ## 2.2. `execute if` selection
-The execute commands permits to verify conditions with the `if` argument [[ wiki ](https://minecraft.fandom.com/wiki/Commands/execute)].
+The execute commands permits to verify conditions with the `if` argument [[ wiki ](https://minecraft.wiki/w/Commands/execute)].
 
 
 In addition to the entity selectors, you can — and it is recommanded — to use the `if` argument. There is a variant of the `if` argument which is `unless` equivalent to "if not".
@@ -315,7 +315,7 @@ Another way to replace commands running from `minecraft/tags/tick.json` is to us
 So we can use this functionality to use built-in conditions for advancements.
 
 
-You can find the full list of triggers on [this page](https://minecraft.fandom.com/wiki/Advancement/JSON_format#List_of_triggers) of the wiki.
+You can find the full list of triggers on [this page](https://minecraft.wiki/w/Advancement/JSON_format#List_of_triggers) of the wiki.
 
 ⚠️ Using the `minecraft:tick` crtiteria **will not** optimize your code at all.
 
@@ -444,7 +444,7 @@ All references and credits for anyone who participated directly or indirectly in
 2. MCP-Reborn [[ Github Repo ](https://github.com/Hexeption/MCP-Reborn)]
 3. Minecraft Commands' Discord server [[ link ](https://discord.gg/QAFXFtZ)]
 4. [@Misode](https://github.com/misode) McMeta repo [[ Github Repo ](https://github.com/misode/mcmeta)]
-5. Minecraft Wiki [[ link ](https://minecraft.fandom.com/wiki/Minecraft_Wiki)]
+5. Minecraft Wiki [[ link ](https://minecraft.wiki/w/Minecraft_Wiki)]
 6. [u/Wooden_chest](https://www.reddit.com/user/Wooden_chest/) performance tests [[ link ](https://www.reddit.com/r/MinecraftCommands/comments/w4vjs3/whenever_i_create_datapacks_i_sometimes_do/)]
 7. [@capitalists#1171](https://discordapp.com/users/217271293668622344) `type` argument is allways checked (message on MinecraftCommands discord) [ link to message ](https://discord.com/channels/154777837382008833/154777837382008833/985503145239142461)
 

--- a/docs/lang/fr-fr/basics.md
+++ b/docs/lang/fr-fr/basics.md
@@ -86,7 +86,7 @@ Les sélecteurs sont essentiels dans mcfunction. Il y a de nombreuses raisons et
 ### 2.1.1. Quel sélecteur choisir ?
 
 
-`@e` est le sélecteur générique, il sélectionne toutes les entités. À ce sélecteur, vous pouvez ajouter des sélecteurs de cible (vous pouvez les trouver tous [ici sur le wiki [en]](https://minecraft.fandom.com/wiki/Target_selectors)). Donc, pour récapituler, @e[type=minecraft:player] sélectionnera uniquement les joueurs.
+`@e` est le sélecteur générique, il sélectionne toutes les entités. À ce sélecteur, vous pouvez ajouter des sélecteurs de cible (vous pouvez les trouver tous [ici sur le wiki [en]](https://minecraft.wiki/w/Target_selectors)). Donc, pour récapituler, @e[type=minecraft:player] sélectionnera uniquement les joueurs.
 
 
 On peut trouver des propriétés de @e dans d'autres sélecteurs, mais ils ont toujours leurs propres propriétés :
@@ -163,7 +163,7 @@ Avec ces détails, on peut déterminer d'un ordre à respecter:
 
 ## 2.2. Séléction avec `execute if`
 
-La commande /execute permets de vérifier des conditions avec l'argument `if` [[ wiki ](https://minecraft.fandom.com/wiki/Commands/execute)].
+La commande /execute permets de vérifier des conditions avec l'argument `if` [[ wiki ](https://minecraft.wiki/w/Commands/execute)].
 
 En plus du sélécteur d'entitées, vous pouvez — et il est recommandé — d'utiliser l'agument `if`. Il y a une variante `unless` qui est son contraire, un "if not".
 
@@ -310,7 +310,7 @@ Une autre façon de remplacer les commandes tournant depuis `minecraft/tags/tick
 Nous pouvons donc utiliser cette fonctionalitée pour les conditions existantes des advancements au lieu de check une condition tous les ticks.
 
 
-Vous pouvez trouver une liste complète des différents critères sur [cette page](https://minecraft.fandom.com/wiki/Advancement/JSON_format#List_of_triggers) du wiki.
+Vous pouvez trouver une liste complète des différents critères sur [cette page](https://minecraft.wiki/w/Advancement/JSON_format#List_of_triggers) du wiki.
 
 ⚠️ Utiliser le critère `minecraft:tick` **n'optimisera pas** votre code du tout.
 
@@ -434,7 +434,7 @@ Toutes les références et les crédits pour toute personne ayant participé dir
 2. MCP-Reborn [[ Github Repo ](https://github.com/Hexeption/MCP-Reborn)]
 3. Minecraft Commands' Discord server [[ link ](https://discord.gg/QAFXFtZ)]
 4. [@Misode](https://github.com/misode) McMeta repo [[ Github Repo ](https://github.com/misode/mcmeta)]
-5. Minecraft Wiki [[ link ](https://minecraft.fandom.com/wiki/Minecraft_Wiki)]
+5. Minecraft Wiki [[ link ](https://minecraft.wiki/w/Minecraft_Wiki)]
 6. [u/Wooden_chest](https://www.reddit.com/user/Wooden_chest/) performance tests [[ link ](https://www.reddit.com/r/MinecraftCommands/comments/w4vjs3/whenever_i_create_datapacks_i_sometimes_do/)]
 7. [@capitalists#1171](https://discordapp.com/users/217271293668622344) `type` argument is allways checked (message on MinecraftCommands discord) [ link to message ](https://discord.com/channels/154777837382008833/154777837382008833/985503145239142461)
 


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: <https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom>. This PR updates all the URLs to the new domain: minecraft.wiki